### PR TITLE
Add create_key, other things

### DIFF
--- a/crypt-gpgme.gemspec
+++ b/crypt-gpgme.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.extra_rdoc_files = Dir['doc/*.rdoc']
 
   spec.add_dependency('ffi', '~> 1.1')
-  spec.add_dependency('ffi-bitfield', '~> 0.0.10')
+  spec.add_dependency('ffi-bitfield', '~> 0.0.11')
 
   spec.add_development_dependency('rspec')
   spec.add_development_dependency('rspec_boolean')
@@ -23,6 +23,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency('rake')
   spec.add_development_dependency('rubocop')
   spec.add_development_dependency('rubocop-rspec')
+  spec.add_development_dependency('fakefs')
 
   spec.metadata = {
     'homepage_uri'          => 'https://github.com/djberg96/crypt-gpgme',

--- a/lib/crypt/gpgme.rb
+++ b/lib/crypt/gpgme.rb
@@ -9,6 +9,7 @@ require_relative 'gpgme/subkey'
 require_relative 'gpgme/user_id'
 require_relative 'gpgme/key_signature'
 require_relative 'gpgme/revocation_key'
+require_relative 'gpgme/genkey_result'
 
 module Crypt
   class GPGME

--- a/lib/crypt/gpgme/constants.rb
+++ b/lib/crypt/gpgme/constants.rb
@@ -749,6 +749,11 @@ module Crypt
       GPGME_SIG_MODE_CLEAR   = 2
       GPGME_SIG_MODE_ARCHIVE = 4
       GPGME_SIG_MODE_FILE    = 8
+
+      # These value are not really meant to be exposed and could change in
+      # future versions, but I'm not sure what other option we have.
+      GPGME_DELETE_ALLOW_SECRET = 1
+      GPGME_DELETE_FORCE = 2
     end
   end
 end

--- a/lib/crypt/gpgme/constants.rb
+++ b/lib/crypt/gpgme/constants.rb
@@ -754,6 +754,7 @@ module Crypt
       # future versions, but I'm not sure what other option we have.
       GPGME_DELETE_ALLOW_SECRET = 1
       GPGME_DELETE_FORCE = 2
+      GPGME_INCLUDE_CERTS_DEFAULT = (-1 << 8)
     end
   end
 end

--- a/lib/crypt/gpgme/context.rb
+++ b/lib/crypt/gpgme/context.rb
@@ -77,7 +77,7 @@ module Crypt
         if ptr.null?
           false
         else
-          Crypt::GPGME::Structs::GenkeyResult.new(ptr)
+          Crypt::GPGME::GenkeyResult.new(ptr)
         end
       end
 

--- a/lib/crypt/gpgme/context.rb
+++ b/lib/crypt/gpgme/context.rb
@@ -186,8 +186,14 @@ module Crypt
         value
       end
 
-      def protocol
-        gpgme_get_protocol(@ctx.pointer)
+      def protocol(as: 'integer')
+        proto = gpgme_get_protocol(@ctx.pointer)
+
+        if as.to_s == 'string'
+          proto = gpgme_get_protocol_name(proto)
+        end
+
+        proto
       end
 
       def protocol=(proto)
@@ -197,6 +203,8 @@ module Crypt
           errstr = gpgme_strerror(err)
           raise Crypt::GPGME::Error, "gpgme_set_protocol failed: #{errstr}"
         end
+
+        proto
       end
 
       def offline?

--- a/lib/crypt/gpgme/context.rb
+++ b/lib/crypt/gpgme/context.rb
@@ -64,6 +64,23 @@ module Crypt
         arr
       end
 
+      def create_key(userid, algorithm: 'default', expires: 0, flags: 0)
+        err = gpgme_op_createkey(@ctx.pointer, userid, algorithm, 0, expires, nil, flags)
+
+        if err != GPG_ERR_NO_ERROR
+          errstr = gpgme_strerror(err)
+          raise Crypt::GPGME::Error, "gpgme_op_createkey failed: #{errstr}"
+        end
+
+        ptr = gpgme_op_genkey_result(@ctx.pointer)
+
+        if ptr.null?
+          false
+        else
+          Crypt::GPGME::Structs::GenkeyResult.new(ptr)
+        end
+      end
+
       def get_key(fingerprint, secret = true)
         key = FFI::MemoryPointer.new(:pointer)
         err = gpgme_get_key(@ctx.pointer, fingerprint, key, secret)

--- a/lib/crypt/gpgme/data.rb
+++ b/lib/crypt/gpgme/data.rb
@@ -14,6 +14,8 @@ module Crypt
 
         if obj.is_a?(Crypt::GPGME::Structs::Data)
           @data = obj
+        elsif obj.is_a?(FFI::MemoryPointer)
+          @data = Crypt::GPGME::Structs::Data.new(obj)
         else
           @data = Crypt::GPGME::Structs::Data.new
         end

--- a/lib/crypt/gpgme/engine.rb
+++ b/lib/crypt/gpgme/engine.rb
@@ -17,6 +17,8 @@ module Crypt
 
         if obj.is_a?(Crypt::GPGME::Structs::EngineInfo)
           @engine = obj
+        elsif obj.is_a?(FFI::MemoryPointer)
+          @engine = Crypt::GPGME::Structs::EngineInfo.new(obj)
         else
           @engine = Crypt::GPGME::Structs::EngineInfo.new
         end

--- a/lib/crypt/gpgme/functions.rb
+++ b/lib/crypt/gpgme/functions.rb
@@ -66,6 +66,8 @@ module Crypt
       attach_function :gpgme_op_createkey_start, [Structs::Context, :string, :string, :uint, :uint, Structs::Key, :uint], :uint
       attach_function :gpgme_op_createsubkey, [Structs::Context, Structs::Key, :string, :uint, :uint, :uint], :uint
       attach_function :gpgme_op_createsubkey_start, [Structs::Context, Structs::Key, :string, :uint, :uint, :uint], :uint
+      attach_function :gpgme_op_delete, [Structs::Context, Structs::Key, :uint], :uint
+      attach_function :gpgme_op_delete_ext, [Structs::Context, Structs::Key, :uint], :uint
       attach_function :gpgme_op_export, [Structs::Context, :string, :uint, :pointer], :uint
       attach_function :gpgme_op_export_start, [Structs::Context, :string, :uint, :pointer], :uint
       attach_function :gpgme_op_export_ext, [Structs::Context, :string, :uint, :pointer], :uint

--- a/lib/crypt/gpgme/genkey_result.rb
+++ b/lib/crypt/gpgme/genkey_result.rb
@@ -1,0 +1,49 @@
+require 'forwardable'
+require_relative 'subkey'
+require_relative 'user_id'
+require_relative 'revocation_key'
+
+module Crypt
+  class GPGME
+    class GenkeyResult
+      include Crypt::GPGME::Constants
+      include Crypt::GPGME::Functions
+      extend Forwardable
+
+      def_delegators :@key_result, :primary?, :sub?, :uid
+
+      def initialize(obj)
+        return if obj.nil?
+        return obj if obj.is_a?(Key)
+
+        if obj.is_a?(Crypt::GPGME::Structs::GenkeyResult)
+          @key_result = obj
+        else
+          @key_result = Crypt::GPGME::Structs::GenkeyResult.new(obj)
+        end
+      end
+
+      def object
+        @key_result
+      end
+
+      def to_hash
+        @key_result.to_hash
+      end
+
+      def fpr
+        @key_result[:fpr]
+      end
+
+      alias fingerprint fpr
+
+      def pubkey
+        @key_result[:pubkey]
+      end
+
+      def seckey
+        @key_result[:seckey]
+      end
+    end
+  end
+end

--- a/lib/crypt/gpgme/key.rb
+++ b/lib/crypt/gpgme/key.rb
@@ -20,6 +20,8 @@ module Crypt
 
         if obj.is_a?(Crypt::GPGME::Structs::Key)
           @key = obj
+        elsif obj.is_a?(FFI::MemoryPointer)
+          @key = Crypt::GPGME::Structs::Key.new(obj)
         else
           @key = Crypt::GPGME::Structs::Key.new
         end

--- a/lib/crypt/gpgme/key_signature.rb
+++ b/lib/crypt/gpgme/key_signature.rb
@@ -16,6 +16,8 @@ module Crypt
 
         if obj.is_a?(Crypt::GPGME::Structs::KeySignature)
           @keysig = obj
+        elsif obj.is_a?(FFI::MemoryPointer)
+          @keysig = Crypt::GPGME::Structs::KeySignature.new(obj)
         else
           @keysig = Crypt::GPGME::Structs::KeySignature.new
         end

--- a/lib/crypt/gpgme/revocation_key.rb
+++ b/lib/crypt/gpgme/revocation_key.rb
@@ -15,6 +15,8 @@ module Crypt
 
         if obj.is_a?(Crypt::GPGME::Structs::RevocationKey)
           @revkey = obj
+        elsif obj.is_a?(FFI::MemoryPointer)
+          @revkey = Crypt::GPGME::Structs::RevocationKey.new(obj)
         else
           @revkey = Crypt::GPGME::Structs::RevocationKey.new
         end

--- a/lib/crypt/gpgme/structs.rb
+++ b/lib/crypt/gpgme/structs.rb
@@ -49,6 +49,12 @@ module Crypt
         end
       end
 
+      # gpgme_genkey_result_t
+      class GenkeyResult < FFI::BitStruct
+        layout(:_properties, :uint, :fpr, :string, :pubkey, :pointer, :seckey, :pointer)
+        bit_fields(:_properties, :primary, 1, :sub, 1, :uid, 1, :_unused, 29)
+      end
+
       # gpgme_op_keylist_result_t
       class KeylistResult < FFI::BitStruct
         layout(:_properties, :uint)

--- a/lib/crypt/gpgme/subkey.rb
+++ b/lib/crypt/gpgme/subkey.rb
@@ -18,6 +18,8 @@ module Crypt
 
         if obj.is_a?(Crypt::GPGME::Structs::Subkey)
           @subkey = obj
+        elsif obj.is_a?(FFI::MemoryPointer)
+          @subkey = Crypt::GPGME::Structs::Subkey.new(obj)
         else
           @subkey = Crypt::GPGME::Structs::Subkey.new
         end

--- a/lib/crypt/gpgme/user_id.rb
+++ b/lib/crypt/gpgme/user_id.rb
@@ -16,6 +16,8 @@ module Crypt
 
         if obj.is_a?(Crypt::GPGME::Structs::UserId)
           @userid = obj
+        elsif obj.is_a?(FFI::MemoryPointer)
+          @userid = Crypt::GPGME::Structs::UserId.new(obj)
         else
           @userid = Crypt::GPGME::Structs::UserId.new
         end

--- a/spec/crypt_gpgme_algorithm_spec.rb
+++ b/spec/crypt_gpgme_algorithm_spec.rb
@@ -1,6 +1,4 @@
-require 'rspec'
-require 'rspec_boolean'
-require 'crypt/gpgme'
+require 'spec_helper'
 
 RSpec.describe Crypt::GPGME::Algorithm do
   example 'pubkey_algorithm_name basic functionality' do

--- a/spec/crypt_gpgme_context_spec.rb
+++ b/spec/crypt_gpgme_context_spec.rb
@@ -93,6 +93,15 @@ RSpec.describe Crypt::GPGME::Context do
     end
 
     example 'include_certs returns an expected value' do
+      expect(subject.include_certs).to eq(Crypt::GPGME::GPGME_INCLUDE_CERTS_DEFAULT)
+    end
+
+    example 'include_certs= basic functionality' do
+      expect(subject).to respond_to(:include_certs=)
+    end
+
+    example 'include_certs= works as expected' do
+      expect(subject.include_certs = 1).to eq(1)
       expect(subject.include_certs).to eq(1)
     end
   end

--- a/spec/crypt_gpgme_context_spec.rb
+++ b/spec/crypt_gpgme_context_spec.rb
@@ -1,6 +1,4 @@
-require 'rspec'
-require 'rspec_boolean'
-require 'crypt/gpgme'
+require 'spec_helper'
 
 RSpec.describe Crypt::GPGME::Context do
   subject{ described_class.new }

--- a/spec/crypt_gpgme_context_spec.rb
+++ b/spec/crypt_gpgme_context_spec.rb
@@ -90,4 +90,30 @@ RSpec.describe Crypt::GPGME::Context do
       expect(result[:fpr]).to be_a(String)
     end
   end
+
+  context 'delete key', :tempfs do
+    let(:engine){ subject.get_engine_info.first }
+    let(:userid){ 'bogus@bogus.com' }
+    let(:create_flags) { Crypt::GPGME::GPGME_CREATE_NOPASSWD }
+    let(:delete_flags) { Crypt::GPGME::GPGME_DELETE_ALLOW_SECRET | Crypt::GPGME::GPGME_DELETE_FORCE }
+
+    before do |example|
+      subject.set_engine_info(engine.protocol, engine.file_name, example.metadata[:tmpdir])
+    end
+
+    after do
+      subject.set_engine_info(engine.protocol, engine.file_name, engine.home_dir)
+    end
+
+    example 'delete_key basic functionality' do
+      expect(subject).to respond_to(:delete_key)
+    end
+
+    example 'delete_key works as expected with a string argument' do
+      subject.create_key(userid, flags: create_flags)
+      size = subject.list_keys.size
+      expect(subject.delete_key(userid, force: true)).to be(true)
+      expect(subject.list_keys.size).to eq(size - 1)
+    end
+  end
 end

--- a/spec/crypt_gpgme_context_spec.rb
+++ b/spec/crypt_gpgme_context_spec.rb
@@ -62,20 +62,16 @@ RSpec.describe Crypt::GPGME::Context do
     end
   end
 
-  context 'create key' do
+  context 'create key', :tempfs do
     let(:engine){ subject.get_engine_info.first }
     let(:userid){ 'bogus@bogus.com' }
     let(:flags) { Crypt::GPGME::GPGME_CREATE_NOPASSWD }
 
-    before do
-      @tmpdir = Dir.mktmpdir
-      @original_dir = Dir.pwd
-      Dir.chdir(@tmpdir)
-      subject.set_engine_info(engine.protocol, engine.file_name, @tmpdir)
+    before do |example|
+      subject.set_engine_info(engine.protocol, engine.file_name, example.metadata[:tmpdir])
     end
 
     after do
-      Dir.chdir(@original_dir)
       subject.set_engine_info(engine.protocol, engine.file_name, engine.home_dir)
     end
 

--- a/spec/crypt_gpgme_context_spec.rb
+++ b/spec/crypt_gpgme_context_spec.rb
@@ -62,6 +62,30 @@ RSpec.describe Crypt::GPGME::Context do
     end
   end
 
+  context 'protocol' do
+    example 'protocol basic functionality' do
+      expect(subject).to respond_to(:protocol)
+      expect(subject.protocol).to be_a(Integer)
+    end
+
+    example 'protocol optionally returns a string' do
+      expect(subject.protocol(as: 'string')).to be_a(String)
+    end
+
+    example 'protocol returns expected value' do
+      expect(subject.protocol).to eq(0)
+      expect(subject.protocol(as: 'string')).to eq('OpenPGP')
+    end
+
+    example 'protocol= basic functionality' do
+      expect(subject).to respond_to(:protocol=)
+    end
+
+    example 'protocol= works as expected' do
+      expect(subject.protocol = 0).to eq(0)
+    end
+  end
+
   context 'create key', :tempfs do
     let(:engine){ subject.get_engine_info.first }
     let(:userid){ 'bogus@bogus.com' }

--- a/spec/crypt_gpgme_context_spec.rb
+++ b/spec/crypt_gpgme_context_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'tmpdir'
 
 RSpec.describe Crypt::GPGME::Context do
   subject{ described_class.new }
@@ -58,6 +59,54 @@ RSpec.describe Crypt::GPGME::Context do
       expect(engine.version).to be_a(String)
       expect(engine.req_version).to be_a(String)
       expect(engine.home_dir).to be_a(String).or be_nil
+    end
+  end
+
+  context 'create key' do
+    let(:engine){ subject.get_engine_info.first }
+    let(:tmpdir){ Dir.mktmpdir }
+    let(:userid){ 'bogus@bogus.com' }
+    let(:flags) { Crypt::GPGME::GPGME_CREATE_NOPASSWD }
+
+    before do
+      # Create directories with proper permissions
+      FileUtils.mkdir_p(tmpdir, mode: 0700)
+      FileUtils.mkdir_p(File.join(tmpdir, 'private-keys-v1.d'), mode: 0700)
+      FileUtils.mkdir_p(File.join(tmpdir, 'openpgp-revocs.d'), mode: 0700)
+      FileUtils.mkdir_p(File.join(tmpdir, 'public-keys.d'), mode: 0755)
+
+      # Create required files with proper permissions
+      FileUtils.touch(File.join(tmpdir, 'pubring.kbx'))
+      FileUtils.touch(File.join(tmpdir, 'trustdb.gpg'))
+      FileUtils.touch(File.join(tmpdir, 'sshcontrol'))
+      FileUtils.touch(File.join(tmpdir, 'common.conf'))
+
+      # Set permissions
+      File.chmod(0600, File.join(tmpdir, 'trustdb.gpg'))
+      File.chmod(0644, File.join(tmpdir, 'common.conf'))
+      File.chmod(0600, File.join(tmpdir, 'sshcontrol'))
+
+      @original_home = ENV['GNUPGHOME']
+      ENV['GNUPGHOME'] = tmpdir
+
+      @size = subject.list_keys.size
+      subject.set_engine_info(engine.protocol, engine.file_name, tmpdir)
+    end
+
+    after do
+      ENV['GNUPGHOME'] = @original_home
+      subject.set_engine_info(engine.protocol, engine.file_name, engine.home_dir)
+      FileUtils.remove_entry_secure(tmpdir) if File.directory?(tmpdir)
+    end
+
+    example 'create_key basic functionality' do
+      expect(subject).to respond_to(:create_key)
+    end
+
+    example 'create_key works as expected' do
+      subject.pinentry_mode = Crypt::GPGME::GPGME_PINENTRY_MODE_LOOPBACK
+      expect(subject.create_key(userid, flags: flags)).to be_a(Crypt::GPGME::Structs::GenkeyResult)
+      expect(subject.list_keys.size).to eq(@size + 1)
     end
   end
 end

--- a/spec/crypt_gpgme_context_spec.rb
+++ b/spec/crypt_gpgme_context_spec.rb
@@ -112,7 +112,17 @@ RSpec.describe Crypt::GPGME::Context do
     example 'delete_key works as expected with a string argument' do
       subject.create_key(userid, flags: create_flags)
       size = subject.list_keys.size
+
       expect(subject.delete_key(userid, force: true)).to be(true)
+      expect(subject.list_keys.size).to eq(size - 1)
+    end
+
+    example 'delete_key works as expected with a key argument' do
+      subject.create_key(userid, flags: create_flags)
+      key_object = subject.list_keys(pattern: userid).first
+      size = subject.list_keys.size
+
+      expect(subject.delete_key(key_object, force: true)).to be(true)
       expect(subject.list_keys.size).to eq(size - 1)
     end
   end

--- a/spec/crypt_gpgme_context_spec.rb
+++ b/spec/crypt_gpgme_context_spec.rb
@@ -84,5 +84,10 @@ RSpec.describe Crypt::GPGME::Context do
       expect(subject.create_key(userid, flags: flags)).to be_a(Crypt::GPGME::Structs::GenkeyResult)
       expect(subject.list_keys.size).to eq(size + 1)
     end
+
+    example 'create_key return value has expected result' do
+      result = subject.create_key('bogus2@bogus.com', flags: flags)
+      expect(result[:fpr]).to be_a(String)
+    end
   end
 end

--- a/spec/crypt_gpgme_context_spec.rb
+++ b/spec/crypt_gpgme_context_spec.rb
@@ -86,6 +86,17 @@ RSpec.describe Crypt::GPGME::Context do
     end
   end
 
+  context 'include certs' do
+    example 'include_certs basic functionality' do
+      expect(subject).to respond_to(:include_certs)
+      expect(subject.include_certs).to be_a(Integer)
+    end
+
+    example 'include_certs returns an expected value' do
+      expect(subject.include_certs).to eq(1)
+    end
+  end
+
   context 'create key', :tempfs do
     let(:engine){ subject.get_engine_info.first }
     let(:userid){ 'bogus@bogus.com' }
@@ -115,7 +126,7 @@ RSpec.describe Crypt::GPGME::Context do
     end
   end
 
-  context 'get_key', :tempfs do
+  context 'get key', :tempfs do
     let(:engine){ subject.get_engine_info.first }
     let(:userid){ 'bogus@bogus.com' }
     let(:create_flags) { Crypt::GPGME::GPGME_CREATE_NOPASSWD }
@@ -148,7 +159,7 @@ RSpec.describe Crypt::GPGME::Context do
     end
   end
 
-  context 'delete_key', :tempfs do
+  context 'delete key', :tempfs do
     let(:engine){ subject.get_engine_info.first }
     let(:userid){ 'bogus@bogus.com' }
     let(:create_flags) { Crypt::GPGME::GPGME_CREATE_NOPASSWD }

--- a/spec/crypt_gpgme_context_spec.rb
+++ b/spec/crypt_gpgme_context_spec.rb
@@ -64,39 +64,19 @@ RSpec.describe Crypt::GPGME::Context do
 
   context 'create key' do
     let(:engine){ subject.get_engine_info.first }
-    let(:tmpdir){ Dir.mktmpdir }
     let(:userid){ 'bogus@bogus.com' }
     let(:flags) { Crypt::GPGME::GPGME_CREATE_NOPASSWD }
 
     before do
-      # Create directories with proper permissions
-      FileUtils.mkdir_p(tmpdir, mode: 0700)
-      FileUtils.mkdir_p(File.join(tmpdir, 'private-keys-v1.d'), mode: 0700)
-      FileUtils.mkdir_p(File.join(tmpdir, 'openpgp-revocs.d'), mode: 0700)
-      FileUtils.mkdir_p(File.join(tmpdir, 'public-keys.d'), mode: 0755)
-
-      # Create required files with proper permissions
-      FileUtils.touch(File.join(tmpdir, 'pubring.kbx'))
-      FileUtils.touch(File.join(tmpdir, 'trustdb.gpg'))
-      FileUtils.touch(File.join(tmpdir, 'sshcontrol'))
-      FileUtils.touch(File.join(tmpdir, 'common.conf'))
-
-      # Set permissions
-      File.chmod(0600, File.join(tmpdir, 'trustdb.gpg'))
-      File.chmod(0644, File.join(tmpdir, 'common.conf'))
-      File.chmod(0600, File.join(tmpdir, 'sshcontrol'))
-
-      @original_home = ENV['GNUPGHOME']
-      ENV['GNUPGHOME'] = tmpdir
-
-      @size = subject.list_keys.size
-      subject.set_engine_info(engine.protocol, engine.file_name, tmpdir)
+      @tmpdir = Dir.mktmpdir
+      @original_dir = Dir.pwd
+      Dir.chdir(@tmpdir)
+      subject.set_engine_info(engine.protocol, engine.file_name, @tmpdir)
     end
 
     after do
-      ENV['GNUPGHOME'] = @original_home
+      Dir.chdir(@original_dir)
       subject.set_engine_info(engine.protocol, engine.file_name, engine.home_dir)
-      FileUtils.remove_entry_secure(tmpdir) if File.directory?(tmpdir)
     end
 
     example 'create_key basic functionality' do
@@ -104,9 +84,9 @@ RSpec.describe Crypt::GPGME::Context do
     end
 
     example 'create_key works as expected' do
-      subject.pinentry_mode = Crypt::GPGME::GPGME_PINENTRY_MODE_LOOPBACK
+      size = subject.list_keys.size
       expect(subject.create_key(userid, flags: flags)).to be_a(Crypt::GPGME::Structs::GenkeyResult)
-      expect(subject.list_keys.size).to eq(@size + 1)
+      expect(subject.list_keys.size).to eq(size + 1)
     end
   end
 end

--- a/spec/crypt_gpgme_engine_spec.rb
+++ b/spec/crypt_gpgme_engine_spec.rb
@@ -1,6 +1,4 @@
-require 'rspec'
-require 'rspec_boolean'
-require 'crypt/gpgme'
+require 'spec_helper'
 
 RSpec.describe Crypt::GPGME::Engine do
   subject{ described_class.new(true) }

--- a/spec/crypt_gpgme_spec.rb
+++ b/spec/crypt_gpgme_spec.rb
@@ -3,9 +3,7 @@
 #
 # Specs for the crypt-gpgme library.
 #######################################################################
-require 'rspec'
-require 'rspec_boolean'
-require 'crypt/gpgme'
+require 'spec_helper'
 
 RSpec.describe Crypt::GPGME do
   example 'version is set to expected value' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,8 @@
+require 'rspec'
+require 'rspec_boolean'
+require 'fakefs/spec_helpers'
+require 'crypt/gpgme'
+
+RSpec.configure do |config|
+  config.include FakeFS::SpecHelpers, fakefs: true
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,15 @@
 require 'rspec'
 require 'rspec_boolean'
 require 'fakefs/spec_helpers'
+require 'tmpdir'
 require 'crypt/gpgme'
 
 RSpec.configure do |config|
   config.include FakeFS::SpecHelpers, fakefs: true
+  config.around(:example, :tempfs) do |example|
+    Dir.mktmpdir do |tmpdir|
+      example.metadata['tmpdir'] = tmpdir
+      example.run
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,9 +7,15 @@ require 'crypt/gpgme'
 RSpec.configure do |config|
   config.include FakeFS::SpecHelpers, fakefs: true
   config.around(:example, :tempfs) do |example|
+    original_home = ENV['GNUPGHOME']
+
     Dir.mktmpdir do |tmpdir|
+      ENV['GNUPGHOME'] = tmpdir
+
       example.metadata['tmpdir'] = tmpdir
       example.run
+
+      ENV['GNUPGHOME'] = original_home
     end
   end
 end


### PR DESCRIPTION
Adds the create_key and delete_key methods, updates the constructors on our wrapper classes, and adds specs.

It also updates the spec helper so that we can create a temporary filesystem where we can make changes without affecting our real key.